### PR TITLE
chore: add new branch for prod and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ This Turborepo includes the following packages and applications:
 - `apps/next`: Landing page with Next.js.
 - `apps/react`: Core React components.
 - [`packages/color`](./packages/color/README.md): Chromatrix color converter library.
-- [`packages/coverage`](./packages/color/README.md): Testing color library.
+- [`packages/coverage`](./packages/coverage/README.md): Testing color library.

--- a/apps/next/build.sh
+++ b/apps/next/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "next" ]] ; then
+if [[ "$VERCEL_GIT_COMMIT_REF" == "prod" || "$VERCEL_GIT_COMMIT_REF" == "dev" ]] ; then
   exit 1;
 else
   exit 0;

--- a/apps/next/src/app/page.tsx
+++ b/apps/next/src/app/page.tsx
@@ -11,10 +11,10 @@ export default function Home(): JSX.Element {
         <p className="text-gray-200">The Holy Colors</p>
       </div>
       <Link
-        href="https://github.com/r-sp/chromatrix"
+        href="/github"
         className="text-matrix-200 font-medium"
         target="_blank"
-        rel="nofolow noopener"
+        rel="noopener"
       >
         Preview
       </Link>

--- a/apps/next/vercel.json
+++ b/apps/next/vercel.json
@@ -19,10 +19,10 @@
   ],
   "git": {
     "deploymentEnabled": {
+      "prod": true,
+      "dev": true,
       "main": false,
-      "packages": false,
-      "next": true,
-      "staging": true
+      "packages": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "engines": {
     "node": ">=22.x"
   },
-  "packageManager": "pnpm@10.6.3",
+  "packageManager": "pnpm@10.7.1",
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",


### PR DESCRIPTION
the new branch is dedicated for production and preview environment, previously we use `next` as prod and `staging` as preview, those branch name is not efficient.
